### PR TITLE
Force version jsonapi extras 2.10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,6 @@
 .github                   export-ignore
 tests                     export-ignore
 circle.yml                export-ignore
-composer.json             export-ignore
 composer.lock             export-ignore
 phpcs.xml                 export-ignore
 phpunit.xml               export-ignore

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "drupal-module",
     "license": "GPL-2.0+",
     "require": {
-        "drupal/jsonapi": "1.16",
-        "drupal/jsonapi_extras": "2.5",
+        "drupal/jsonapi": "^1.16",
+        "drupal/jsonapi_extras": "2.10",
         "drupal/schemata": "1.0-alpha2",
         "drupal/openapi": "1.0-alpha1",
         "dpc-sdp/tide_core": "@dev"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0+",
     "require": {
         "drupal/jsonapi": "1.16",
-        "drupal/jsonapi_extras": "2.9",
+        "drupal/jsonapi_extras": "2.6",
         "drupal/schemata": "1.0-alpha2",
         "drupal/openapi": "1.0-alpha1",
         "dpc-sdp/tide_core": "@dev"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0+",
     "require": {
         "drupal/jsonapi": "1.16",
-        "drupal/jsonapi_extras": "2.10",
+        "drupal/jsonapi_extras": "2.9",
         "drupal/schemata": "1.0-alpha2",
         "drupal/openapi": "1.0-alpha1",
         "dpc-sdp/tide_core": "@dev"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0+",
     "require": {
         "drupal/jsonapi": "1.16",
-        "drupal/jsonapi_extras": "2.6",
+        "drupal/jsonapi_extras": "2.5",
         "drupal/schemata": "1.0-alpha2",
         "drupal/openapi": "1.0-alpha1",
         "dpc-sdp/tide_core": "@dev"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0+",
     "require": {
         "drupal/jsonapi": "1.16",
-        "drupal/jsonapi_extras": "2.0-rc1",
+        "drupal/jsonapi_extras": "2.10",
         "drupal/schemata": "1.0-alpha2",
         "drupal/openapi": "1.0-alpha1",
         "dpc-sdp/tide_core": "@dev"


### PR DESCRIPTION
1. Force to use JSONAPI extra 2.10, because 2.11 break compatibility with Drupal 8.5.x