### PR TITLE
[SDPA-2016] Re enable Vimedo Embed Video

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "drupal/jsonapi_extras": "^2.5",
         "drupal/schemata": "^1.0-alpha2",
         "drupal/openapi": "^1.0-alpha1",
+        "drupal/metatag": "~1.7.0",
         "dpc-sdp/tide_core": "^1.0"
     },
     "suggest": {

--- a/src/Plugin/jsonapi/FieldEnhancer/EmbedVideoEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/EmbedVideoEnhancer.php
@@ -73,8 +73,6 @@ class EmbedVideoEnhancer extends ResourceFieldEnhancerBase implements ContainerF
    *   The embeddable url.
    */
   public function parseVideos($video = NULL) {
-    /** @var \Symfony\Component\HttpFoundation\Request $request */
-    $request = \Drupal::requestStack()->getCurrentRequest();
 
     // Check for iframe to get the video url.
     if (strpos($video, 'iframe') !== FALSE) {
@@ -149,9 +147,9 @@ class EmbedVideoEnhancer extends ResourceFieldEnhancerBase implements ContainerF
               $video_id = $results[1];
 
               try {
-                $hash = unserialize(file_get_contents($request->getScheme() . "://vimeo.com/api/v2/video/$video_id.php"));
+                $hash = unserialize(file_get_contents("https://vimeo.com/api/v2/video/$video_id.php"));
                 if (!empty($hash) && is_array($hash)) {
-                  $video_str = $request->getScheme() . '://player.vimeo.com/video/%s';
+                  $video_str = 'https://player.vimeo.com/video/%s';
                 }
                 else {
                   // Don't use, couldn't find what we need.

--- a/src/Plugin/jsonapi/FieldEnhancer/EmbedVideoEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/EmbedVideoEnhancer.php
@@ -73,6 +73,8 @@ class EmbedVideoEnhancer extends ResourceFieldEnhancerBase implements ContainerF
    *   The embeddable url.
    */
   public function parseVideos($video = NULL) {
+    /** @var \Symfony\Component\HttpFoundation\Request $request */
+    $request = \Drupal::requestStack()->getCurrentRequest();
 
     // Check for iframe to get the video url.
     if (strpos($video, 'iframe') !== FALSE) {
@@ -147,9 +149,9 @@ class EmbedVideoEnhancer extends ResourceFieldEnhancerBase implements ContainerF
               $video_id = $results[1];
 
               try {
-                $hash = unserialize(file_get_contents("//vimeo.com/api/v2/video/$video_id.php"));
+                $hash = unserialize(file_get_contents($request->getScheme() . "://vimeo.com/api/v2/video/$video_id.php"));
                 if (!empty($hash) && is_array($hash)) {
-                  $video_str = '//vimeo.com/moogaloop.swf?clip_id=%s';
+                  $video_str = $request->getScheme() . '://player.vimeo.com/video/%s';
                 }
                 else {
                   // Don't use, couldn't find what we need.


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-2016

** Issues **: 
composer.json in tide_api references tide_core:^1.0
composer.json in tide_core references metatag:^1.7

It also references `metatag_2945817_28.patch`, which doesn’t work with 1.8 and only with 1.7
this update will require updates to tide_core before it can pass.

Tide core will be updated today, but if CR  pass we could send QA because of content-vic works without problem.

Related PRs: 
* Content PR:  https://github.com/dpc-sdp/content-vic-gov-au/pull/500

### Changed

1. Assign request schema to Vimeo request. Removed at https://github.com/dpc-sdp/tide_api/commit/8a5ee5b1ad4a462e3a07d16f237fae43acf2c511#diff-b9db188acad684367230ef0742554decL149
2. replace deprecated flash payer. More Info https://vimeo.zendesk.com/hc/en-us/articles/360001359507-Flash-player-deprecation 

### Screenshots
![screen shot 2019-02-21 at 3 45 58 pm](https://user-images.githubusercontent.com/907914/53144645-32f7c580-35f1-11e9-90a0-c13d8665cec9.png)


<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
