### PR TITLE
Upgraded JSON:API 2.4 and JSON:API Extras 3.8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "dpc-sdp/tide_core": "^1.2.5",
-        "drupal/jsonapi": "~2.3.0",
-        "drupal/jsonapi_extras": "~3.4.0",
+        "drupal/jsonapi": "^2.4",
+        "drupal/jsonapi_extras": "^3.8",
         "drupal/schemata": "^1.0-alpha2"
     },
     "suggest": {
@@ -18,9 +18,6 @@
         "patches": {
             "drupal/core": {
                 "Menu content is not accessible via jsonapi - https://www.drupal.org/node/2915792": "https://www.drupal.org/files/issues/menu_link_content-view-permissions-2915792.patch"
-            },
-            "drupal/jsonapi_extras": {
-                "JSON:API Extras 3.4 adds enhanced field values outside of attributes for Config Entities - https://www.drupal.org/project/jsonapi_extras/issues/3037833": "https://www.drupal.org/files/issues/2019-03-06/jsonapi_extras-config_entities_enhancer-3037833-4.patch"
             }
         }
     },

--- a/src/Access/EntityAccessChecker.php
+++ b/src/Access/EntityAccessChecker.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\tide_api\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\jsonapi\Access\EntityAccessChecker as JsonapiEntityAccessChecker;
+use Drupal\paragraphs\Entity\Paragraph;
+
+/**
+ * Class EntityAccessChecker.
+ *
+ * @package Drupal\tide_api\Access
+ */
+class EntityAccessChecker extends JsonapiEntityAccessChecker {
+
+  /**
+   * {@inheritdoc}
+   *
+   * @see https://www.drupal.org/project/jsonapi/issues/2992833#comment-12818258
+   * @see https://www.drupal.org/project/drupal/issues/3043321
+   */
+  protected function checkRevisionViewAccess(EntityInterface $entity, AccountInterface $account) {
+    // The ParagraphAccessControlHandler already checks for access.
+    if ($entity instanceof Paragraph) {
+      return AccessResult::allowed();
+    }
+    return parent::checkRevisionViewAccess($entity, $account);
+  }
+
+}

--- a/src/IncludeResolver.php
+++ b/src/IncludeResolver.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\tide_api;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\RevisionableStorageInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
+use Drupal\entity_reference_revisions\Plugin\Field\FieldType\EntityReferenceRevisionsItem;
+use Drupal\jsonapi\Exception\EntityAccessDeniedHttpException;
+use Drupal\jsonapi\IncludeResolver as JsonapiIncludeResolver;
+use Drupal\jsonapi\JsonApiResource\Data;
+use Drupal\jsonapi\JsonApiResource\IncludedData;
+use Drupal\jsonapi\JsonApiResource\LabelOnlyResourceObject;
+use Drupal\jsonapi\JsonApiResource\ResourceIdentifierInterface;
+use Drupal\jsonapi\JsonApiResource\ResourceObject;
+
+/**
+ * Class IncludeResolver.
+ *
+ * @package Drupal\tide_api
+ */
+class IncludeResolver extends JsonapiIncludeResolver {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Allows JSON:API to load the correct revision of included Paragraphs
+   * when loading an unpublished revision of a Node.
+   *
+   * @see \Drupal\jsonapi\IncludeResolver::resolveIncludeTree()
+   */
+  protected function resolveIncludeTree(array $include_tree, Data $data, Data $includes = NULL) {
+    $includes = is_null($includes) ? new IncludedData([]) : $includes;
+    foreach ($include_tree as $field_name => $children) {
+      $references = [];
+      foreach ($data as $resource_object) {
+        // Some objects in the collection may be LabelOnlyResourceObjects or
+        // EntityAccessDeniedHttpException objects.
+        assert($resource_object instanceof ResourceIdentifierInterface);
+        if ($resource_object instanceof LabelOnlyResourceObject) {
+          $message = "The current user is not allowed to view this relationship.";
+          $exception = new EntityAccessDeniedHttpException($resource_object->getEntity(), AccessResult::forbidden("The user only has authorization for the 'view label' operation."), '', $message, $field_name);
+          $includes = IncludedData::merge($includes, new IncludedData([$exception]));
+          continue;
+        }
+        elseif (!$resource_object instanceof ResourceObject) {
+          continue;
+        }
+        $public_field_name = $resource_object->getResourceType()->getPublicName($field_name);
+        // Not all entities in $entity_collection will be of the same bundle and
+        // may not have all of the same fields. Therefore, calling
+        // $resource_object->get($a_missing_field_name) will result in an
+        // exception.
+        if (!$resource_object->hasField($public_field_name)) {
+          continue;
+        }
+        $field_list = $resource_object->getField($public_field_name);
+        // Config entities don't have real fields and can't have relationships.
+        if (!$field_list instanceof FieldItemListInterface) {
+          continue;
+        }
+        $field_access = $field_list->access('view', NULL, TRUE);
+        if (!$field_access->isAllowed()) {
+          $message = 'The current user is not allowed to view this relationship.';
+          $exception = new EntityAccessDeniedHttpException($field_list->getEntity(), $field_access, '', $message, $public_field_name);
+          $includes = IncludedData::merge($includes, new IncludedData([$exception]));
+          continue;
+        }
+        $target_type = $field_list->getFieldDefinition()->getFieldStorageDefinition()->getSetting('target_type');
+        assert(!empty($target_type));
+        foreach ($field_list as $field_item) {
+          assert($field_item instanceof EntityReferenceItem);
+          // Include the target_revision_id in the references of paragraphs.
+          $target_type = $field_item->getDataDefinition()->getSetting('target_type');
+          if ($field_item instanceof EntityReferenceRevisionsItem && $target_type == 'paragraph') {
+            $references[$target_type][$field_item->get($field_item::mainPropertyName())->getValue()] = $field_item->get('target_revision_id')->getValue();
+          }
+          else {
+            $references[$target_type][] = $field_item->get($field_item::mainPropertyName())->getValue();
+          }
+        }
+      }
+      foreach ($references as $target_type => $ids) {
+        $entity_storage = $this->entityTypeManager->getStorage($target_type);
+        // Load the revisions of the included Paragraphs.
+        if ($entity_storage instanceof RevisionableStorageInterface && $target_type == 'paragraph') {
+          $targeted_entities = $entity_storage->loadMultipleRevisions(array_unique(array_values($ids)));
+        }
+        else {
+          $targeted_entities = $entity_storage->loadMultiple(array_unique($ids));
+        }
+        $access_checked_entities = array_map(function (EntityInterface $entity) {
+          return $this->entityAccessChecker->getAccessCheckedResourceObject($entity);
+        }, $targeted_entities);
+        $targeted_collection = new IncludedData(array_filter($access_checked_entities, function (ResourceIdentifierInterface $resource_object) {
+          return !$resource_object->getResourceType()->isInternal();
+        }));
+        $includes = static::resolveIncludeTree($children, $targeted_collection, IncludedData::merge($includes, $targeted_collection));
+      }
+    }
+    return $includes;
+  }
+
+}

--- a/src/TideApiServiceProvider.php
+++ b/src/TideApiServiceProvider.php
@@ -22,6 +22,16 @@ class TideApiServiceProvider extends ServiceProviderBase {
       $definition->setClass('\Drupal\tide_api\EventSubscriber\TideApiJsonApiRequestValidator');
       $definition->setArguments([new Reference('module_handler')]);
     }
+
+    if ($container->hasDefinition('jsonapi.include_resolver')) {
+      $definition = $container->getDefinition('jsonapi.include_resolver');
+      $definition->setClass('\Drupal\tide_api\IncludeResolver');
+    }
+
+    if ($container->hasDefinition('jsonapi.entity_access_checker')) {
+      $definition = $container->getDefinition('jsonapi.entity_access_checker');
+      $definition->setClass('\Drupal\tide_api\Access\EntityAccessChecker');
+    }
   }
 
 }


### PR DESCRIPTION
JIRA: https://digital-engagement.atlassian.net/browse/SDPA-2779

* Upgraded JSON:API to 8.x-2.4.
* Upgrade JSON:API Extras to 8.x-3.8.
* Added workaround to allow JSON:API to load the correct revision of included paragraphs of an unpublished revision of a node.


On-behalf-of: @salsadigitalauorg <sonny@salsadigital.com.au>