### PR TITLE
[SDPA-2966] disable read only in jsonapi.settings

### DIFF
--- a/tide_api.install
+++ b/tide_api.install
@@ -15,10 +15,13 @@ function tide_api_install() {
   $config_factory = \Drupal::configFactory();
   $config_factory->getEditable('jsonapi_extras.settings')->set('path_prefix', 'api/v1')->save();
   $config_factory->getEditable('jsonapi_extras.settings')->set('include_count', TRUE)->save();
+  // Update jsonpai.settings['read_only'] to FALSE.
+  $config_factory->getEditable('jsonapi.settings')->set('read_only', FALSE)->save(TRUE);
 
   // Allow users with Anonymous and Authenticated roles to access API.
   Role::load('anonymous')->grantPermission('access jsonapi resource list')->save();
   Role::load('authenticated')->grantPermission('access jsonapi resource list')->save();
+
 }
 
 /**


### PR DESCRIPTION
issues:
https://digital-engagement.atlassian.net/projects/SDPA/issues/SDPA-2966
https://digital-engagement.atlassian.net/projects/SDPA/issues/SDPA-2932
I think there is no `drush updatedb` script in module `build_suggest` task, to set `jsonapi.settings` - read_only to FALSE, we probably have to set it from `tide_api_install()` function. 