### PR TITLE
[SDPA-3936] Added function to process text that converts node link to path alias.

### DIFF
--- a/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
@@ -5,6 +5,7 @@ namespace Drupal\tide_api\Plugin\jsonapi\FieldEnhancer;
 use Drupal\Core\Serialization\Yaml;
 use Drupal\jsonapi_extras\Plugin\ResourceFieldEnhancerBase;
 use Shaper\Util\Context;
+use Drupal\Component\Utility\Html;
 
 /**
  * Decode YAML content.
@@ -21,7 +22,9 @@ class YamlEnhancer extends ResourceFieldEnhancerBase {
    * {@inheritdoc}
    */
   protected function doUndoTransform($data, Context $context) {
-    return Yaml::decode($data);
+    $data = $this->processText($data);
+
+    return $data;
   }
 
   /**
@@ -45,6 +48,41 @@ class YamlEnhancer extends ResourceFieldEnhancerBase {
         ['type' => 'string'],
       ],
     ];
+  }
+
+  /**
+   * Helper function to convert node urls to path alias.
+   *
+   * @param string $data
+   *   Data from a webform.
+   *
+   * @return formattted data
+   */
+  public function processText($data) {
+    $formatted_data = Yaml::decode($data);
+    $processed_text = $formatted_data['processed_text']['#text'];
+    if (strpos($processed_text, 'data-entity-type') !== FALSE && strpos($processed_text, 'data-entity-uuid') !== FALSE) {
+      $dom = Html::load($processed_text);
+      $xpath = new \DOMXPath($dom);
+      foreach ($xpath->query('//a[@data-entity-type and @data-entity-uuid]') as $element) {
+        /** @var \DOMElement $element */
+        try {
+          $entity_type = $element->getAttribute('data-entity-type');
+          if ($entity_type == 'node') {
+            $href = $element->getAttribute('href');
+            $aliasByPath = \Drupal::service('path.alias_manager')->getAliasByPath($href);
+            $alias_helper = \Drupal::service('tide_site.alias_storage_helper');
+            $url = $alias_helper->getPathAliasWithoutSitePrefix(['alias' => $aliasByPath]);
+            $element->setAttribute('href', $url);
+          }
+        }
+        catch (\Exception $e) {
+          watchdog_exception('YamlEnhancer_processText', $e);
+        }
+      }
+      $formatted_data['processed_text']['#text'] = Html::serialize($dom);
+    }
+    return $formatted_data;
   }
 
 }

--- a/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
@@ -66,6 +66,7 @@ class YamlEnhancer extends ResourceFieldEnhancerBase {
    *   The string value of the field.
    *
    * @return string
+   *   The processed text.
    */
   public function processText($text) {
     $result = $text;

--- a/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
@@ -93,4 +93,5 @@ class YamlEnhancer extends ResourceFieldEnhancerBase {
     }
     return $result;
   }
+
 }


### PR DESCRIPTION
### JIRA
https://digital-engagement.atlassian.net/browse/SDPA-3936

### Issue
The json response for webform markup and processed_text elements doesn't send node path alias when embedded. Because of that FE points to the node-link. See the Departments privacy statement link at the end of the form ([link](https://www.aboriginalvictoria.vic.gov.au/strong-roots-our-futures-program-peer-assessors-panel#privacy-and-information-management)).

### Changes
The webform using the Yaml enhancer for its elements. A process text function is added in the YAML enhancer, which will return a text by converting the link into path alias without the site id. In this method `doUndoTransform($data, Context $context)` it checks for the two elements of a webform and if the elements have text then it calls that function to process the text.

### Testing PRs 
Content-vic - https://github.com/dpc-sdp/content-vic-gov-au/pull/901 ([Test link](https://nginx-php-content-vic-pr-901.lagoon.vicsdp.amazee.io/))
vic-gov-au - https://github.com/dpc-sdp/vic-gov-au/pull/750 ([Test link](https://app-vic-gov-au-pr-750.lagoon.vicsdp.amazee.io/))