### PR TITLE
[SDPA-6018] Embedded videos not displaying on transcript pages.

### DIFF
--- a/src/Plugin/jsonapi/FieldEnhancer/EmbedVideoEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/EmbedVideoEnhancer.php
@@ -145,20 +145,7 @@ class EmbedVideoEnhancer extends ResourceFieldEnhancerBase implements ContainerF
           if ($videoIdRegex !== NULL) {
             if (preg_match($videoIdRegex, $link, $results)) {
               $video_id = $results[1];
-
-              try {
-                $hash = unserialize(file_get_contents("https://vimeo.com/api/v2/video/$video_id.php"));
-                if (!empty($hash) && is_array($hash)) {
-                  $video_str = 'https://player.vimeo.com/video/%s';
-                }
-                else {
-                  // Don't use, couldn't find what we need.
-                  unset($video_id);
-                }
-              }
-              catch (\Exception $e) {
-                unset($video_id);
-              }
+              $video_str = 'https://player.vimeo.com/video/%s';
             }
           }
         }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-6018

This bug is to do with how Vimeo videos domain-level privacy settings refused to connect. Identified that the bug cannot handle domain-level privacy settings. Removal of the restriction will allow handling of both public and domain-level privacy Vimeo video.

### Changed

1. Fixes domain level or privacy vimeo url.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
![Screen Shot 2022-03-11 at 10 09 20 am](https://user-images.githubusercontent.com/67810118/157770499-386c0328-5409-4828-9200-79ec69631d5c.png)
![Screen Shot 2022-03-11 at 10 11 22 am](https://user-images.githubusercontent.com/67810118/157770781-00e489b6-418e-4e1c-a1bb-4b457ec6f66b.png)
![Screen Shot 2022-03-11 at 9 38 45 am](https://user-images.githubusercontent.com/67810118/157770297-791a1450-180c-439b-ac34-39c40a664bfe.png)
![Screen Shot 2022-03-11 at 9 39 13 am](https://user-images.githubusercontent.com/67810118/157770311-c9ddd410-b5ad-4b6e-9385-668dcac39569.png)

