### PR TITLE
[SDPAP-6606] Hide content collection JSON string from content.

### DIFF
--- a/modules/tide_content_collection/config/install/core.entity_view_display.paragraph.content_collection.default.yml
+++ b/modules/tide_content_collection/config/install/core.entity_view_display.paragraph.content_collection.default.yml
@@ -17,7 +17,7 @@ content:
     region: content
     label: above
     settings:
-      raw_json: '0'
+      raw_json: 0
     third_party_settings: {  }
 hidden:
   search_api_excerpt: true

--- a/modules/tide_content_collection/config/install/core.entity_view_display.paragraph.content_collection.default.yml
+++ b/modules/tide_content_collection/config/install/core.entity_view_display.paragraph.content_collection.default.yml
@@ -17,7 +17,7 @@ content:
     region: content
     label: above
     settings:
-      raw_json: 0
+      raw_json: '1'
     third_party_settings: {  }
 hidden:
   search_api_excerpt: true

--- a/modules/tide_content_collection/config/install/core.entity_view_display.paragraph.content_collection_enhanced.default.yml
+++ b/modules/tide_content_collection/config/install/core.entity_view_display.paragraph.content_collection_enhanced.default.yml
@@ -33,7 +33,7 @@ content:
     weight: 0
     label: above
     settings:
-      raw_json: '1'
+      raw_json: '0'
     third_party_settings: {  }
     type: content_collection_configuration_raw
     region: content

--- a/modules/tide_content_collection/tide_content_collection.install
+++ b/modules/tide_content_collection/tide_content_collection.install
@@ -93,7 +93,7 @@ function tide_content_collection_update_8002() {
   $config = \Drupal::configFactory()
     ->getEditable('core.entity_view_display.paragraph.content_collection.default');
   if ($config) {
-    $config->set('content.field_content_collection_config.settings.raw_json', '0');
+    $config->set('content.field_content_collection_config.settings.raw_json', 0);
     $config->save();
   }
 }

--- a/modules/tide_content_collection/tide_content_collection.install
+++ b/modules/tide_content_collection/tide_content_collection.install
@@ -91,7 +91,7 @@ function _assign_content_collection_perm_site_admin() {
  */
 function tide_content_collection_update_8002() {
   $config = \Drupal::configFactory()
-    ->getEditable('core.entity_view_display.paragraph.content_collection.default');
+    ->getEditable('core.entity_view_display.paragraph.content_collection_enhanced.default');
   if ($config) {
     $config->set('content.field_content_collection_config.settings.raw_json', 0);
     $config->save();


### PR DESCRIPTION
**JIRA ISSUE:** https://digital-vic.atlassian.net/browse/SDPAP-6606

### Changed
Hide content collection JSON raw data from content.
Fix from issue found #89 where the checkbox was changed in the wrong collection.
Reverted custom collection back to show json. 

**Environment:** 
https://nginx-php.pr-176.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/

**Test results (updated)**: https://digital-vic.atlassian.net/browse/SDPAP-6606?focusedCommentId=145378

JSON not displayed in Content Collection for Landing Page
![image](https://user-images.githubusercontent.com/67810118/202590669-20e39150-d492-4e8e-82b8-3b5dd73082c5.png)

JSON displayed for Custom Collection
![image](https://user-images.githubusercontent.com/67810118/202590683-f7193da3-b55b-43a9-972f-a5e3ea12a4ac.png)
