### PR TITLE
[SRM-702] Fix for revision loading throws error on illegal offset type.

### DIFF
--- a/modules/tide_share_link/src/Controller/ShareLinkTokenController.php
+++ b/modules/tide_share_link/src/Controller/ShareLinkTokenController.php
@@ -130,14 +130,11 @@ class ShareLinkTokenController extends ControllerBase {
 
     if ($node && $node instanceof NodeInterface) {
       // Attempt to retrieve the node revision.
-      $vid = $this->routeMatch->getParameter('node_revision');
-      if ($vid && is_int($vid)) {
-        $revision = $this->entityTypeManager()->getStorage('node')->loadRevision($vid);
-        if ($revision && $revision->id() === $node->id()) {
-          return AccessResult::allowedIf($revision->access('view', $account))
-            ->addCacheableDependency($revision)
-            ->addCacheableDependency($account);
-        }
+      $revision = $this->routeMatch->getParameter('node_revision');
+      if ($revision && $revision->id() === $node->id()) {
+        return AccessResult::allowedIf($revision->access('view', $account))
+          ->addCacheableDependency($revision)
+          ->addCacheableDependency($account);
       }
       else {
         return AccessResult::allowedIf($node->access('view', $account))

--- a/modules/tide_share_link/src/Controller/ShareLinkTokenController.php
+++ b/modules/tide_share_link/src/Controller/ShareLinkTokenController.php
@@ -131,7 +131,7 @@ class ShareLinkTokenController extends ControllerBase {
     if ($node && $node instanceof NodeInterface) {
       // Attempt to retrieve the node revision.
       $vid = $this->routeMatch->getParameter('node_revision');
-      if ($vid) {
+      if ($vid && is_int($vid)) {
         $revision = $this->entityTypeManager()->getStorage('node')->loadRevision($vid);
         if ($revision && $revision->id() === $node->id()) {
           return AccessResult::allowedIf($revision->access('view', $account))

--- a/modules/tide_share_link/src/Controller/ShareLinkTokenController.php
+++ b/modules/tide_share_link/src/Controller/ShareLinkTokenController.php
@@ -130,8 +130,9 @@ class ShareLinkTokenController extends ControllerBase {
 
     if ($node && $node instanceof NodeInterface) {
       // Attempt to retrieve the node revision.
+      // This should return the id directly.
       $revision = $this->routeMatch->getParameter('node_revision');
-      if ($revision && $revision->id() === $node->id()) {
+      if ($revision && $revision === $node->id()) {
         return AccessResult::allowedIf($revision->access('view', $account))
           ->addCacheableDependency($revision)
           ->addCacheableDependency($account);


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SRM-702

### Issue
Some of the $vid values returned as object and which causes illegal offset type error when calling the `loadRevision` function.
Scenario - Go to a node in any CMS and click on the revision tab. Then click on any previous revision and then the CMS will throw error.

### Changes
9.4 returns the vid directly from here - `$revision = $this->routeMatch->getParameter('node_revision');`
https://github.com/dpc-sdp/tide_api/issues/100