### PR TITLE
Custom menu endpoint for use with Ripple 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # To ignore OS temporary files use global .gitignore
 # https://help.github.com/articles/ignoring-files/#create-a-global-gitignore
-
+.idea
 /composer.lock
 /composer.build.json
 /composer.build.lock

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,9 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "^3.1.12",
+        "dpc-sdp/tide_core": "*",
         "drupal/jsonapi_extras": "^3.8",
+        "drupal/jsonapi_menu_items": "^1.2",
         "drupal/schemata": "^1.0-alpha2"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
             },
             "drupal/jsonapi_extras": {
               "Make max value of page[limit] configurable per entity/bundle - https://www.drupal.org/project/jsonapi_extras/issues/2884292#comment-14794882": "https://www.drupal.org/files/issues/2022-11-21/max_page_limit_configuration-2884292-33.patch"
+            },
+            "drupal/jsonapi_menu_items": {
+                "Allow filtering of response payload - https://www.drupal.org/project/jsonapi_menu_items/issues/3350524": "https://www.drupal.org/files/issues/2023-03-31/filter_fields.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "*",
+        "dpc-sdp/tide_core": "^3.1.12",
         "drupal/jsonapi_extras": "^3.8",
         "drupal/jsonapi_menu_items": "^1.2",
         "drupal/schemata": "^1.0-alpha2"

--- a/tide_api.info.yml
+++ b/tide_api.info.yml
@@ -5,6 +5,7 @@ package: Tide
 core_version_requirement: ^8.9 || ^9
 dependencies:
   - drupal:jsonapi_extras (>=8.x-3.8)
+  - drupal:jsonapi_menu_items (^1.2)
   - drupal:schemata
   - drupal:schemata_json_schema
 config_devel:

--- a/tide_api.install
+++ b/tide_api.install
@@ -44,3 +44,12 @@ function tide_api_update_8001() {
   $jsonapi_settings->set('read_only', FALSE)
     ->save(TRUE);
 }
+
+/**
+ * Activate jsonapi_menu_items
+ */
+function tide_api_update_8002() {
+  \Drupal::service('module_installer')->install([
+    'jsonapi_menu_items'
+  ], TRUE);
+}

--- a/tide_api.install
+++ b/tide_api.install
@@ -46,10 +46,10 @@ function tide_api_update_8001() {
 }
 
 /**
- * Activate jsonapi_menu_items
+ * Activate jsonapi_menu_items.
  */
 function tide_api_update_8002() {
   \Drupal::service('module_installer')->install([
-    'jsonapi_menu_items'
+    'jsonapi_menu_items',
   ], TRUE);
 }


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/R20-456

This PR adds a contrib module for pulling down menu contents in one request, rather than many. It also has a patch to allow the requesting front end to filter what response fields they want in order to reduce the payload.

@MdNadimHossain @vincent-gao @anthony-malkoun please review