### PR TITLE
[SDPAP-7855] Allow undefined include in a request, so response is 200 rather than 400

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Please follow these rules:
-1. SUBJECT: use format [SUPSSP-123] Verb in past tense with dot at the end.
+1. SUBJECT: use format [SDPAP-123] Verb in past tense with dot at the end.
    - This subject will be used as a commit message after PR is merged.
    - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
    - If there is no ticket - do not put [NOTICKET].

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Please follow these rules:
+1. SUBJECT: use format [SUPSSP-123] Verb in past tense with dot at the end.
+   - This subject will be used as a commit message after PR is merged.
+   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
+   - If there is no ticket - do not put [NOTICKET].
+
+2. BODY: fill-in the template below
+
+3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.
+
+4. ASSIGNEE: Assign at least 2 reviewers.
+
+5. SLACK: Post a link to this PR to #sdp-tide / #sdp-dev channels.
+
+No need to remove these lines - they are comments.
+-->
+
+**JIRA issue:** https://digital-vic.atlassian.net/browse/SUPSSP-
+
+### Changed
+
+1.
+
+### Screenshots
+
+<!--
+Provide as many screenshots as required to make reviewers understand what was changed.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Please follow these rules:
 No need to remove these lines - they are comments.
 -->
 
-**JIRA issue:** https://digital-vic.atlassian.net/browse/SUPSSP-
+**JIRA issue:** https://digital-vic.atlassian.net/browse/SDPAP-
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Content API functionality of [Tide](https://github.com/dpc-sdp/tide) distributio
 [![CircleCI](https://circleci.com/gh/dpc-sdp/tide_api.svg?style=svg)](https://circleci.com/gh/dpc-sdp/tide_api)
 
 ## Tide
-Tide is a Drupal 8 distribution focused on delivering an API first, headless 
+Tide is a Drupal 8 distribution focused on delivering an API first, headless
 Drupal content administration site.
 
 # CONTENTS OF THIS FILE
@@ -15,14 +15,14 @@ Drupal content administration site.
 * Installation
 
 # INTRODUCTION
-The Tide API module provides the content API functionality and related 
-configurations. This module is required in case you want to use your site in a 
+The Tide API module provides the content API functionality and related
+configurations. This module is required in case you want to use your site in a
 headless manner.
 
 ## Redirects
-This module introduces a wildcard redirect feature. Redirects using the 
-Redirects module can be added with a `%` at the end in order to create wildcard 
-redirects. E.g. `/my-path%` will match `/my-path-title`, 
+This module introduces a wildcard redirect feature. Redirects using the
+Redirects module can be added with a `%` at the end in order to create wildcard
+redirects. E.g. `/my-path%` will match `/my-path-title`,
 `my-path/sub-folder/path` and `/my-path-other-title`.
 
 # REQUIREMENTS
@@ -38,10 +38,22 @@ Include the Tide API module in your composer.json file
 composer require dpc-sdp/tide_api
 ```
 
+## Development and maintenance
+Development is powered by [Dev-Tools](https://github.com/dpc-sdp/dev-tools). Please refer to Dev-Tools'
+page for [system requirements](https://github.com/dpc-sdp/dev-tools/#prerequisites) and other details.
+
+To start local development stack:
+1. Checkout this project
+2. Ensure other projects using our dev stack are stopped
+3. Run `./dev-tools.sh`
+4. Run `ahoy build`
+5. Use `ahoy login` to gain access to the CMS (or use the one time login link given at end of build)
+6. Use `ahoy lint && ahoy test-behat` to run CI tests
+
 # Caveats
 
-Tide API is on the alpha release, use with caution. APIs are likely to change 
-before the stable version, that there will be breaking changes and that we're 
+Tide API is on the alpha release, use with caution. APIs are likely to change
+before the stable version, that there will be breaking changes and that we're
 not supporting it for external production sites at the moment.
 
 # Attribution

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "dev-reference",
+        "dpc-sdp/tide_core": "^3.1.12",
         "drupal/jsonapi_extras": "^3.8",
         "drupal/jsonapi_menu_items": "^1.2",
         "drupal/schemata": "^1.0-alpha2"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "^3.1.12",
+        "dpc-sdp/tide_core": "dev-reference",
         "drupal/jsonapi_extras": "^3.8",
         "drupal/jsonapi_menu_items": "^1.2",
         "drupal/schemata": "^1.0-alpha2"

--- a/src/TideApiFieldResolver.php
+++ b/src/TideApiFieldResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\tide_api;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Http\Exception\CacheableBadRequestHttpException;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\jsonapi\Context\FieldResolver;
+use Drupal\jsonapi\ResourceType\ResourceType;
+use Drupal\jsonapi\ResourceType\ResourceTypeRepositoryInterface;
+
+class TideApiFieldResolver extends FieldResolver {
+
+  /**
+   * Original service object.
+   *
+   * @var \Drupal\jsonapi\Context\FieldResolver
+   */
+  protected $innerService;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(FieldResolver $original_field_resolver, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $field_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, ResourceTypeRepositoryInterface $resource_type_repository, ModuleHandlerInterface $module_handler, AccountInterface $current_user = NULL) {
+    $this->innerService = $original_field_resolver;
+    parent::__construct($entity_type_manager, $field_manager, $entity_type_bundle_info, $resource_type_repository, $module_handler, $current_user);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function resolveInternalIncludePath(ResourceType $resource_type, array $path_parts, $depth = 0): array {
+    $cacheability = (new CacheableMetadata())->addCacheContexts(['url.query_args:include']);
+    $public_field_name = $path_parts[0];
+    $internal_field_name = $resource_type->getInternalName($public_field_name);
+    $relatable_resource_types = $resource_type->getRelatableResourceTypesByField($public_field_name);
+    $remaining_parts = array_slice($path_parts, 1);
+    if (empty($remaining_parts)) {
+      return [[$internal_field_name]];
+    }
+    $exceptions = [];
+    $resolved = [];
+    foreach ($relatable_resource_types as $relatable_resource_type) {
+      try {
+        // Each resource type may resolve the path differently and may return
+        // multiple possible resolutions.
+        $resolved = array_merge($resolved, static::resolveInternalIncludePath($relatable_resource_type, $remaining_parts, $depth + 1));
+      }
+      catch (CacheableBadRequestHttpException $e) {
+        $exceptions[] = $e;
+      }
+    }
+    if (!empty($exceptions) && count($exceptions) === count($relatable_resource_types)) {
+      $previous_messages = implode(' ', array_unique(array_map(function (CacheableBadRequestHttpException $e) {
+        return $e->getMessage();
+      }, $exceptions)));
+      // Only add the full include path on the first level of recursion so that
+      // the invalid path phrase isn't repeated at every level.
+      throw new CacheableBadRequestHttpException($cacheability, $depth === 0
+        ? sprintf("`%s` is not a valid include path. $previous_messages", implode('.', $path_parts))
+        : $previous_messages
+      );
+    }
+    // Remove duplicates by converting to strings and then using array_unique().
+    $resolved_as_strings = array_map(function ($possibility) {
+      return implode('.', $possibility);
+    }, $resolved);
+    $resolved_as_strings = array_unique($resolved_as_strings);
+
+    // The resolved internal paths do not include the current field name because
+    // resolution happens in a recursive process. Convert back from strings.
+    return array_map(function ($possibility) use ($internal_field_name) {
+      return array_merge([$internal_field_name], explode('.', $possibility));
+    }, $resolved_as_strings);
+  }
+}

--- a/src/TideApiFieldResolver.php
+++ b/src/TideApiFieldResolver.php
@@ -13,14 +13,15 @@ use Drupal\jsonapi\Context\FieldResolver;
 use Drupal\jsonapi\ResourceType\ResourceType;
 use Drupal\jsonapi\ResourceType\ResourceTypeRepositoryInterface;
 
+/**
+ * {@inheritdoc}
+ */
 class TideApiFieldResolver extends FieldResolver {
 
   /**
    * Original service object.
-   *
-   * @var \Drupal\jsonapi\Context\FieldResolver
    */
-  protected $innerService;
+  protected FieldResolver $innerService;
 
   /**
    * {@inheritdoc}
@@ -77,4 +78,5 @@ class TideApiFieldResolver extends FieldResolver {
       return array_merge([$internal_field_name], explode('.', $possibility));
     }, $resolved_as_strings);
   }
+
 }

--- a/src/TideApiIncludeResolver.php
+++ b/src/TideApiIncludeResolver.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\tide_api;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\jsonapi\Access\EntityAccessChecker;
+use Drupal\jsonapi\JsonApiResource\IncludedData;
+use Drupal\jsonapi\JsonApiResource\ResourceObject;
+use Drupal\jsonapi\JsonApiResource\ResourceObjectData;
+use Drupal\jsonapi\ResourceType\ResourceType;
+
+/**
+ * Resolves included resources for an entity or collection of entities.
+ *
+ * @internal JSON:API maintains no PHP API since its API is the HTTP API. This
+ *   class may change at any time and this will break any dependencies on it.
+ *
+ * @see https://www.drupal.org/project/drupal/issues/3032787
+ * @see jsonapi.api.php
+ */
+class TideApiIncludeResolver extends IncludeResolver {
+
+  /**
+   * Original service object.
+   *
+   * @var \Drupal\jsonapi\IncludeResolver
+   */
+  protected $innerService;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(\Drupal\jsonapi\IncludeResolver $original_include_resolver, EntityTypeManagerInterface $entity_type_manager, EntityAccessChecker $entity_access_checker) {
+    $this->innerService = $original_include_resolver;
+    parent::__construct($entity_type_manager, $entity_access_checker);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolve($data, $include_parameter) {
+    assert($data instanceof ResourceObject || $data instanceof ResourceObjectData);
+    $data = $data instanceof ResourceObjectData ? $data : new ResourceObjectData([$data], 1);
+    $include_tree = self::toIncludeTree($data, $include_parameter);
+    return IncludedData::deduplicate($this->resolveIncludeTree($include_tree, $data));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static function toIncludeTree(ResourceObjectData $data, $include_parameter) {
+    // $include_parameter: 'one.two.three, one.two.four'.
+    $include_paths = array_map('trim', explode(',', $include_parameter));
+    // $exploded_paths: [['one', 'two', 'three'], ['one', 'two', 'four']].
+    $exploded_paths = array_map(function ($include_path) {
+      return array_map('trim', explode('.', $include_path));
+    }, $include_paths);
+    $resolved_paths_per_resource_type = [];
+    /** @var \Drupal\jsonapi\JsonApiResource\ResourceIdentifierInterface $resource_object */
+    foreach ($data as $resource_object) {
+      $resource_type = $resource_object->getResourceType();
+      $resource_type_name = $resource_type->getTypeName();
+      if (isset($resolved_paths_per_resource_type[$resource_type_name])) {
+        continue;
+      }
+      $resolved_paths_per_resource_type[$resource_type_name] = self::resolveInternalIncludePaths($resource_type, $exploded_paths);
+    }
+    $resolved_paths = array_reduce($resolved_paths_per_resource_type, 'array_merge', []);
+    return static::buildTree($resolved_paths);
+  }
+
+  /**
+   * Resolves an array of public field paths.
+   *
+   * @param \Drupal\jsonapi\ResourceType\ResourceType $base_resource_type
+   *   The base resource type from which to resolve an internal include path.
+   * @param array $paths
+   *   An array of exploded include paths.
+   *
+   * @return array
+   *   An array of all possible internal include paths derived from the given
+   *   public include paths.
+   *
+   * @see self::buildTree
+   */
+  protected static function resolveInternalIncludePaths(ResourceType $base_resource_type, array $paths) {
+    $internal_paths = array_map(function ($exploded_path) use ($base_resource_type) {
+      if (empty($exploded_path)) {
+        return [];
+      }
+      return \Drupal::service('jsonapi.field_resolver')->resolveInternalIncludePath($base_resource_type, $exploded_path);
+    }, $paths);
+    $flattened_paths = array_reduce($internal_paths, 'array_merge', []);
+    return $flattened_paths;
+  }
+}

--- a/src/TideApiIncludeResolver.php
+++ b/src/TideApiIncludeResolver.php
@@ -4,33 +4,26 @@ namespace Drupal\tide_api;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\jsonapi\Access\EntityAccessChecker;
+use Drupal\jsonapi\IncludeResolver;
 use Drupal\jsonapi\JsonApiResource\IncludedData;
 use Drupal\jsonapi\JsonApiResource\ResourceObject;
 use Drupal\jsonapi\JsonApiResource\ResourceObjectData;
 use Drupal\jsonapi\ResourceType\ResourceType;
 
 /**
- * Resolves included resources for an entity or collection of entities.
- *
- * @internal JSON:API maintains no PHP API since its API is the HTTP API. This
- *   class may change at any time and this will break any dependencies on it.
- *
- * @see https://www.drupal.org/project/drupal/issues/3032787
- * @see jsonapi.api.php
+ * {@inheritdoc}
  */
 class TideApiIncludeResolver extends IncludeResolver {
 
   /**
    * Original service object.
-   *
-   * @var \Drupal\jsonapi\IncludeResolver
    */
-  protected $innerService;
+  protected IncludeResolver $innerService;
 
   /**
    * {@inheritdoc}
    */
-  public function __construct(\Drupal\jsonapi\IncludeResolver $original_include_resolver, EntityTypeManagerInterface $entity_type_manager, EntityAccessChecker $entity_access_checker) {
+  public function __construct(IncludeResolver $original_include_resolver, EntityTypeManagerInterface $entity_type_manager, EntityAccessChecker $entity_access_checker) {
     $this->innerService = $original_include_resolver;
     parent::__construct($entity_type_manager, $entity_access_checker);
   }
@@ -93,4 +86,5 @@ class TideApiIncludeResolver extends IncludeResolver {
     $flattened_paths = array_reduce($internal_paths, 'array_merge', []);
     return $flattened_paths;
   }
+
 }

--- a/tests/behat/features/content.feature
+++ b/tests/behat/features/content.feature
@@ -31,7 +31,7 @@ Feature: Page
     And the JSON node "data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000000"
 
     # Validate that a rubbish include request returns 200 OK
-    When I send a GET request to "api/v1/node/test/99999999-aaaa-bbbb-ccc-000000000000?include=node,abcd1234"
+    When I send a GET request to "api/v1/node/test/99999999-aaaa-bbbb-ccc-000000000000?include=abcd1234"
     Then the response code should be 200
     And the response should be in JSON
     And the JSON node "links.self" should exist
@@ -39,6 +39,7 @@ Feature: Page
     And the JSON node "data" should exist
     And the JSON node "data.type" should be equal to "node--test"
     And the JSON node "data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000000"
+    And the JSON node "included" should not exist
 
     When I send a GET request to "api/v1/node/test?sort=-created"
     Then the response code should be 200

--- a/tests/behat/features/content.feature
+++ b/tests/behat/features/content.feature
@@ -30,6 +30,16 @@ Feature: Page
     And the JSON node "data.type" should be equal to "node--test"
     And the JSON node "data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000000"
 
+    # Validate that a rubbish include request returns 200 OK
+    When I send a GET request to "api/v1/node/test/99999999-aaaa-bbbb-ccc-000000000000?include=node,abcd1234"
+    Then the response code should be 200
+    And the response should be in JSON
+    And the JSON node "links.self" should exist
+    And the JSON node "links.self.href" should contain "api/v1/node/test"
+    And the JSON node "data" should exist
+    And the JSON node "data.type" should be equal to "node--test"
+    And the JSON node "data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000000"
+
     When I send a GET request to "api/v1/node/test?sort=-created"
     Then the response code should be 200
     And the response should be in JSON

--- a/tests/behat/features/share_link.feature
+++ b/tests/behat/features/share_link.feature
@@ -37,14 +37,6 @@ Feature: Share Link
     And the JSON node "data.relationships.shared_node.data.type" should be equal to "node--test"
     And the JSON node "data.relationships.shared_node.data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000000"
 
-    # Fetch the relationship of the node using include
-    When I send a GET request to "api/v1/share_link/99999999-aaaa-bbbb-ccc-000000000001/999999?include=node"
-    Then the response code should be 200
-    And the response should be in JSON
-    And the JSON node "data" should exist
-    And the JSON node "data.type" should be equal to "share_link_token--share_link_token"
-    And the JSON node "data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000001"
-
     # Retrieve the draft with Share Link token header.
     When I set "X-Share-Link-Token" header equal to "99999999-aaaa-bbbb-ccc-000000000001"
     And I send a GET request to "api/v1/node/test/99999999-aaaa-bbbb-ccc-000000000000"
@@ -54,3 +46,29 @@ Feature: Share Link
     And the JSON node "data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000000"
     And the JSON node "data.attributes" should exist
     And the JSON node "data.attributes.title" should be equal to "[TEST] Page title"
+
+  @api @nosuggest
+  Scenario: Request to test relationship fetching with include parameter
+    Given test content:
+      | title             | path             | moderation_state | uuid                                | nid    |
+      | [TEST] Page title | /test-page-alias | published            | 99999999-aaaa-bbbb-ccc-000000000000 | 999999 |
+    Given share_link_token share_link_token entity:
+      | name       | status | uid | nid    | token                               |
+      | Test token | 1      | 1   | 999999 | 99999999-aaaa-bbbb-ccc-000000000001 |
+
+    # Fetch the relationship of the node using include
+    When I send a GET request to "api/v1/share_link/99999999-aaaa-bbbb-ccc-000000000001/999999?include=shared_node"
+    Then the response code should be 200
+    And the response should be in JSON
+    And the JSON node "data" should exist
+    And the JSON node "data.type" should be equal to "share_link_token--share_link_token"
+    And the JSON node "data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000001"
+    And the JSON node "data.attributes" should exist
+    And the JSON node "data.attributes.nid" should exist
+    And the JSON node "data.attributes.nid" should be equal to "999999"
+    And the JSON node "data.relationships" should exist
+    And the JSON node "data.relationships.shared_node" should exist
+    And the JSON node "included" should exist
+    And the JSON node "included[0].type" should be equal to "node--test"
+    And the JSON node "included[0].id" should be equal to "99999999-aaaa-bbbb-ccc-000000000000"
+

--- a/tests/behat/features/share_link.feature
+++ b/tests/behat/features/share_link.feature
@@ -37,6 +37,14 @@ Feature: Share Link
     And the JSON node "data.relationships.shared_node.data.type" should be equal to "node--test"
     And the JSON node "data.relationships.shared_node.data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000000"
 
+    # Fetch the relationship of the node using include
+    When I send a GET request to "api/v1/share_link/99999999-aaaa-bbbb-ccc-000000000001/999999?include=node"
+    Then the response code should be 200
+    And the response should be in JSON
+    And the JSON node "data" should exist
+    And the JSON node "data.type" should be equal to "share_link_token--share_link_token"
+    And the JSON node "data.id" should be equal to "99999999-aaaa-bbbb-ccc-000000000001"
+
     # Retrieve the draft with Share Link token header.
     When I set "X-Share-Link-Token" header equal to "99999999-aaaa-bbbb-ccc-000000000001"
     And I send a GET request to "api/v1/node/test/99999999-aaaa-bbbb-ccc-000000000000"

--- a/tide_api.services.yml
+++ b/tide_api.services.yml
@@ -17,3 +17,25 @@ services:
     arguments: ['@entity_type.manager', '@database', '@config.factory']
     tags:
       - { name: backend_overridable }
+  tide_api.field_resolver:
+    class: Drupal\tide_api\TideApiFieldResolver
+    decorates: jsonapi.field_resolver
+    public: false
+    decoration_priority: 5
+    arguments:
+      - '@tide_api.field_resolver.inner'
+      - '@entity_type.manager'
+      - '@entity_field.manager'
+      - '@entity_type.bundle.info'
+      - '@jsonapi.resource_type.repository'
+      - '@module_handler'
+      - '@current_user'
+  tide_api.include_resolver:
+    class: Drupal\tide_api\TideApiIncludeResolver
+    decorates: jsonapi.include_resolver
+    public: false
+    decoration_priority: 5
+    arguments:
+      - '@tide_api.include_resolver.inner'
+      - '@entity_type.manager'
+      - '@jsonapi.entity_access_checker'


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SUPSSP-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.

5. SLACK: Post a link to this PR to #sdp-tide / #sdp-dev channels.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-vic.atlassian.net/browse/SDPAP-7855

### Changed

1. Adds some classes to be decorated to allow us to bypass the JSONAPI rules pertaining to include requests
2. This means that any include request that doesn't match a field will still return valid fields rather than 400 response
3. Added behat tests to cover these new changes

### Screenshots

N/A
