### PR TITLE
[SDPAP-8001] Fixes an issue for preview links

### DIFF
--- a/modules/tide_share_link/config/install/tide_share_link.settings.yml
+++ b/modules/tide_share_link/config/install/tide_share_link.settings.yml
@@ -1,3 +1,3 @@
-token_role: previewer
+token_role: administrator
 default_expiry: 2592000
 cleanup_in_cron: 1

--- a/modules/tide_share_link/tide_share_link.install
+++ b/modules/tide_share_link/tide_share_link.install
@@ -49,3 +49,11 @@ function tide_share_link_install() {
     }
   }
 }
+
+/**
+ * Changes token role to administrator to avoid 404 response in page previewing.
+ */
+function tide_share_link_update_9001() {
+  $shared_link_config = \Drupal::configFactory()->getEditable('tide_share_link.settings');
+  $shared_link_config->set('token_role', 'administrator')->save();
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8001
https://digital-vic.atlassian.net/browse/SDPSUP-5026

### Issue
 the last release reverted the configuration back to `previewer` role which causes the issue, @RonaldRinaldy just fixed it  by applying `drush config:set tide_share_link.settings token_role administrator`, this PR is a follow-up PR to make the change permanently. 