### PR TITLE
[R20-1457] Added env vars to control the content collection json validation.

### DIFF
--- a/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidget.php
+++ b/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidget.php
@@ -1942,7 +1942,6 @@ class ContentCollectionConfigurationWidget extends StringTextareaWidget implemen
    *   The error array list if exists.
    */
   protected function validateJson(string $json) : array {
-    $env_vars = getenv();
     $errors = [];
     $cc_json_validation = (isset(getenv()['CONTENT_COLLECTION_JSON_VALIDATION'])) ? getenv()['CONTENT_COLLECTION_JSON_VALIDATION'] : FALSE;
 

--- a/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidget.php
+++ b/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidget.php
@@ -1942,7 +1942,10 @@ class ContentCollectionConfigurationWidget extends StringTextareaWidget implemen
    *   The error array list if exists.
    */
   protected function validateJson(string $json) : array {
+    $env_vars = getenv();
     $errors = [];
+    $cc_json_validation = ($env_vars && $env_vars['CONTENT_COLLECTION_JSON_VALIDATION']) ? $env_vars['CONTENT_COLLECTION_JSON_VALIDATION'] : FALSE;
+
     if (!empty($json)) {
       $json_object = json_decode($json);
       if ($json_object === NULL) {
@@ -1951,7 +1954,7 @@ class ContentCollectionConfigurationWidget extends StringTextareaWidget implemen
       else {
         // Validate against the JSON Schema.
         $json_schema = $this->fieldDefinition->getFieldStorageDefinition()->getSetting('schema');
-        if (!empty($json_schema)) {
+        if (!empty($json_schema) && $cc_json_validation == TRUE) {
           $json_schema_object = json_decode($json_schema);
           $schema_storage = new SchemaStorage();
           $schema_storage->addSchema('file://content_collection_configuration_schema', $json_schema_object);

--- a/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidget.php
+++ b/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidget.php
@@ -1944,7 +1944,7 @@ class ContentCollectionConfigurationWidget extends StringTextareaWidget implemen
   protected function validateJson(string $json) : array {
     $env_vars = getenv();
     $errors = [];
-    $cc_json_validation = ($env_vars && $env_vars['CONTENT_COLLECTION_JSON_VALIDATION']) ? $env_vars['CONTENT_COLLECTION_JSON_VALIDATION'] : FALSE;
+    $cc_json_validation = (isset(getenv()['CONTENT_COLLECTION_JSON_VALIDATION'])) ? getenv()['CONTENT_COLLECTION_JSON_VALIDATION'] : FALSE;
 
     if (!empty($json)) {
       $json_object = json_decode($json);

--- a/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidgetRaw.php
+++ b/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidgetRaw.php
@@ -119,13 +119,14 @@ class ContentCollectionConfigurationWidgetRaw extends StringTextareaWidget {
    *   The form state.
    */
   public function validateJson(array $element, FormStateInterface $form_state) {
+    $cc_json_validation = (isset(getenv()['CONTENT_COLLECTION_JSON_VALIDATION'])) ? getenv()['CONTENT_COLLECTION_JSON_VALIDATION'] : FALSE;
     $json = $element['#value'];
     if (!empty($json)) {
       $json_object = json_decode($json);
       if ($json_object === NULL) {
         $form_state->setError($element, t('Invalid JSON.'));
       }
-      elseif ($this->getSetting('schema_validation')) {
+      elseif ($this->getSetting('schema_validation') && $cc_json_validation == TRUE) {
         // Validate against the JSON Schema.
         $json_schema = $this->fieldDefinition->getFieldStorageDefinition()->getSetting('schema');
         if (!empty($json_schema)) {


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPAP-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.

5. SLACK: Post a link to this PR to #sdp-tide / #sdp-dev channels.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-vic.atlassian.net/browse/R20-1457

### Changed

1. Added a environment variable check to control the content collection json validation check. 
2. The validation only required for content-health now, so setting a default value to False to not to do the validation check. Only for content-health, will add a environment variable with a value set to true in CMDB and this will turn on the validation check only for that project.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
