### PR TITLE
Fixed references to GetCacheIdEvent::cacheId

### DIFF
--- a/src/Event/GetCacheIdEvent.php
+++ b/src/Event/GetCacheIdEvent.php
@@ -36,7 +36,7 @@ class GetCacheIdEvent extends Event {
    */
   public function __construct(Request $request, string $cache_id) {
     $this->request = $request;
-    $this->cache_id = $cache_id;
+    $this->cacheId = $cache_id;
   }
 
   /**
@@ -46,7 +46,7 @@ class GetCacheIdEvent extends Event {
    *   Cache id
    */
   public function getCacheId(): string {
-    return $this->cache_id;
+    return $this->cacheId;
   }
 
   /**
@@ -56,7 +56,7 @@ class GetCacheIdEvent extends Event {
    *   The new cache id.
    */
   public function setCacheId(string $cache_id) {
-    $this->cache_id = $cache_id;
+    $this->cacheId = $cache_id;
   }
 
   /**


### PR DESCRIPTION
Fixes huge number of log messages like this

```
Deprecated function: Creation of dynamic property Drupal\tide_api\Event\GetCacheIdEvent::$cache_id is deprecated in Drupal\tide_api\Event\GetCacheIdEvent->__construct() (line 39 of /app/docroot/modules/contrib/tide_api/src/Event/GetCacheIdEvent.php) #0 /app/docroot/core/includes/bootstrap.inc(164): _drupal_error_handler_real()
#1 /app/docroot/modules/contrib/tide_api/src/Event/GetCacheIdEvent.php(39): _drupal_error_handler()
#2 /app/docroot/modules/contrib/tide_api/src/Controller/TideApiController.php(381): Drupal\tide_api\Event\GetCacheIdEvent->__construct()
#3 /app/docroot/modules/contrib/tide_api/src/Controller/TideApiController.php(163): Drupal\tide_api\Controller\TideApiController->initializeCacheId()
#4 [internal function]: Drupal\tide_api\Controller\TideApiController->getRoute()
#5 /app/docroot/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array()
#6 /app/docroot/core/lib/Drupal/Core/Render/Renderer.php(

```