### PR TITLE
remove functions to call fields in content collection

### DIFF
--- a/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidget.php
+++ b/modules/tide_content_collection/src/Plugin/Field/FieldWidget/ContentCollectionConfigurationWidget.php
@@ -547,8 +547,6 @@ class ContentCollectionConfigurationWidget extends StringTextareaWidget implemen
 
     $this->buildContentTab($items, $delta, $element, $form, $form_state, $configuration, $json_object);
     $this->buildLayoutTab($items, $delta, $element, $form, $form_state, $configuration, $json_object);
-    $this->buildFiltersTab($items, $delta, $element, $form, $form_state, $configuration, $json_object);
-    $this->buildAdvancedTab($items, $delta, $element, $form, $form_state, $configuration, $json_object);
 
     return $element;
   }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPAP-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.

5. SLACK: Post a link to this PR to #sdp-tide / #sdp-dev channels.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-vic.atlassian.net/browse/SD-16
Testing BE link: https://nginx-php.pr-1688.content-vic.sdp4.sdp.vic.gov.au/
Testing FE link: https://app.pr-1119.vic-gov-au.sdp4.sdp.vic.gov.au/
### Changed

1. Remove function call to remove the Filters and Advanced tabs.

### Screenshots
![Screenshot 2024-07-25 at 9 28 41 am](https://github.com/user-attachments/assets/df723a62-3543-4da8-8735-e0fc120f14d9)

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
